### PR TITLE
Enable DBT docs to be served

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR /usr/src/dbt/dbt_project
 
 # Install the dbt Postgres adapter. This step will also install dbt-core
 RUN pip install --upgrade pip
-RUN pip install dbt-postgres==1.3.1
+RUN pip install dbt-postgres==1.3.1 pytz
 
 # Install dbt dependencies (as specified in packages.yml file)
 # Build seeds, models and snapshots (and run tests wherever applicable)
-CMD dbt deps && dbt build --profiles-dir profiles && sleep infinity
+CMD dbt deps && dbt build --profiles-dir profiles
+
+# Build and serve docs
+CMD dbt docs serve --profiles-dir profiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install dbt-postgres==1.3.1 pytz
 CMD dbt deps && dbt build --profiles-dir profiles
 
 # Build and serve docs
-CMD dbt docs serve --profiles-dir profiles
+CMD dbt docs generate --profiles-dir profiles && dbt docs serve --profiles-dir profiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,6 @@ services:
     container_name: dbt
     ports:
       - '8080:8080'
-    network_mode: bridge
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     build: .
     image: dbt-dummy
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       retries: 5
   dbt:
     container_name: dbt
+    ports:
+      - '8080:8080'
+    network_mode: bridge
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     build: .
     image: dbt-dummy
     volumes:


### PR DESCRIPTION
## Description:
A feature you may want to consider – serving DBT docs.

Also, if I didn't install `pytz` my docker image didn't build.

## Context
* Addresses this issue: https://github.com/gmyrianthous/dbt-dummy/issues/5